### PR TITLE
feat(COG-28): ItemBase loader scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Cogworks-1.0 are tracked here. The library is **additive 
 ## Unreleased
 
 - fix(COG-56): CreateDebugConsole crashed with "attempt to call a nil value" because TabPanel's eager initial activation fired tab `build` closures that reference `f._buildActions` / `_buildInspectors` / `_buildProfile` / `_buildLog` before those methods are defined further down in `CreateDebugConsole`. TabPanel gains an additive `lazy = true` opt (MODULE_MINOR `15 → 16`) that suppresses the auto-activate; Debug.lua passes it and now calls `panel:SetActiveTab(...)` once every builder is wired (MODULE_MINOR `1 → 2`). Bumps lib MINOR `19 → 20`.
+- feat(COG-28): ItemBase loader + generator (placeholder data file with bundled `tools/generate-item-base.py` for refresh). Bumps lib MINOR `20 → 21`.
 
 ## [0.13.2] — 2026-05-05 — Critical: StaticPopupDialogs taint hotfix (COG-30)
 

--- a/Cogworks-1.0/Cogworks-1.0.lua
+++ b/Cogworks-1.0/Cogworks-1.0.lua
@@ -25,7 +25,7 @@ assert(LibStub:GetLibrary("CallbackHandler-1.0", true), "Cogworks-1.0 requires C
 -- because every consumer ships the same external, the path resolves either way.
 local LIB_LOADER_ADDON = ...
 
-local MAJOR, MINOR = "Cogworks-1.0", 20
+local MAJOR, MINOR = "Cogworks-1.0", 21
 local lib, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end  -- already loaded at this version or newer
 oldminor = oldminor or 0

--- a/Cogworks-1.0/Cogworks-1.0.xml
+++ b/Cogworks-1.0/Cogworks-1.0.xml
@@ -32,4 +32,10 @@
     <Script file="Slash.lua" />
     <Script file="Toast.lua" />
 
+    <!-- ItemBase: data file before loader. The data file assigns
+         CogworksItemBaseData_<locale> to a global; ItemBase.lua picks it up
+         lazily on first ResolveName/GetItem/Load call. -->
+    <Script file="Data\ItemBase-Generated-enUS.lua" />
+    <Script file="ItemBase.lua" />
+
 </Ui>

--- a/Cogworks-1.0/Data/ItemBase-Generated-enUS.lua
+++ b/Cogworks-1.0/Data/ItemBase-Generated-enUS.lua
@@ -1,0 +1,16 @@
+-- AUTO-GENERATED placeholder. Real data file regenerated via tools/generate-item-base.py.
+-- DO NOT EDIT BY HAND.
+--
+-- The data file assigns its table to the well-known global
+-- CogworksItemBaseData_<locale> so Cogworks-1.0/ItemBase.lua can pick it up
+-- after the load manifest evaluates this file. The placeholder uses
+-- version="placeholder" so the loader can detect that no real data has
+-- shipped yet and degrade gracefully.
+
+CogworksItemBaseData_enUS = {
+  version     = "placeholder",
+  generatedAt = "",
+  locale      = "enUS",
+  items       = {},
+  byName      = {},
+}

--- a/Cogworks-1.0/ItemBase.lua
+++ b/Cogworks-1.0/ItemBase.lua
@@ -1,0 +1,254 @@
+-- Cogworks-1.0/ItemBase.lua | Bundled name -> itemID + metadata cache.
+--
+-- Closes the gap left by C_Item.GetItemInfo when the live WoW client has never
+-- cached an item the player is trying to import (FlippingPal exports, TSM
+-- group dumps, PBS lists, etc.). The static cache is regenerated from
+-- Blizzard's Game Data API per major-patch cycle by tools/generate-item-base.py
+-- and shipped as Data/ItemBase-Generated-<locale>.lua.
+--
+-- Loading strategy:
+--   * The data file is a ~3 MB Lua table. We do NOT parse it at addon load —
+--     none of the cogs should pay that cost unless they actually call into
+--     this module. First call to ResolveName / GetItem / Load triggers a
+--     one-shot LoadAddOn / require-style eval; subsequent calls are O(1).
+--   * In-memory after the first parse. No on-demand re-reads.
+--   * All methods are nil/false safe when the data file is absent (nolib
+--     path, partial install, locale fallback miss). Consumers can call them
+--     unguarded and just check the return.
+--
+-- Usage:
+--   local cw = LibStub("Cogworks-1.0", true)
+--   if not cw or not cw.ItemBase then return end
+--
+--   local itemID, meta = cw.ItemBase:ResolveName("Crimson Combatant's Necklace")
+--   local meta         = cw.ItemBase:GetItem(12345)
+--   local resolutions  = cw.ItemBase:ResolveNames({ "Item A", "Item B" })
+--
+--   if cw.ItemBase:IsAvailable() then ... end
+--   cw.ItemBase:OnReady(function() refreshUI() end)
+
+local lib = LibStub("Cogworks-1.0")
+if not lib then return end
+
+-- Module load guard. See Sections.lua for the rationale; bump MODULE_MINOR
+-- alongside the lib MINOR whenever this file's behavior changes.
+local MODULE_MINOR = 1
+lib._modules = lib._modules or {}
+if (lib._modules.ItemBase or 0) >= MODULE_MINOR then return end
+lib._modules.ItemBase = MODULE_MINOR
+
+-- Per-module state. Guard with `or` so re-runs on the same lib don't clobber
+-- an already-warm parse.
+lib._itemBase = lib._itemBase or {
+  loaded      = false,    -- has the lazy parse completed?
+  available   = nil,      -- bool cache for IsAvailable; nil until first probe
+  data        = nil,      -- the full table from the data file
+  readyCbs    = {},       -- pending OnReady callbacks
+}
+
+-- Public namespace. `lib.ItemBase` is what consumers reach for.
+lib.ItemBase = lib.ItemBase or {}
+local ItemBase = lib.ItemBase
+
+-- ----------------------------------------------------------------------------
+-- Internal: locate + parse the data file
+-- ----------------------------------------------------------------------------
+
+-- The data file (Data/ItemBase-Generated-<locale>.lua) is sourced from the
+-- XML manifest right before this loader. WoW's XML script loader doesn't
+-- surface a chunk's `return` value, so the data file assigns its table to
+-- the well-known global CogworksItemBaseData_<locale>. We probe for the
+-- live-locale global first, then fall back to enUS for clients on locales
+-- the suite hasn't shipped yet.
+--
+-- TODO(COG-28): once per-locale data files ship (deDE/frFR/...), extend the
+-- manifest to source each one and update DATA_GLOBALS to enumerate them.
+-- For the scaffold we ship enUS only.
+
+local function localeGlobals()
+  local current = (GetLocale and GetLocale()) or "enUS"
+  if current == "enUS" then
+    return { "CogworksItemBaseData_enUS" }
+  end
+  return {
+    "CogworksItemBaseData_" .. current,
+    "CogworksItemBaseData_enUS",
+  }
+end
+
+local function locateDataTable()
+  for _, name in ipairs(localeGlobals()) do
+    local t = _G[name]
+    if type(t) == "table" then
+      return t
+    end
+  end
+  return nil
+end
+
+-- Probe whether the data file shipped (regardless of whether we've parsed it
+-- yet). We treat the placeholder file (which sets `version = "placeholder"`)
+-- as "not really available" so consumers don't show a stale "item base ready"
+-- toast against an empty table.
+local function probeAvailable()
+  local t = locateDataTable()
+  if not t then return false end
+  if t.version == "placeholder" then return false end
+  if type(t.items) ~= "table" then return false end
+  return true
+end
+
+local function fireReady()
+  local cbs = lib._itemBase.readyCbs
+  lib._itemBase.readyCbs = {}
+  for _, fn in ipairs(cbs) do
+    -- Defensive: a consumer's callback erroring shouldn't strand later ones.
+    pcall(fn)
+  end
+end
+
+-- Force the lazy parse. Idempotent: subsequent calls just return the cached
+-- result. Returns true if a usable data table is now resident; false if the
+-- data file is absent or only the placeholder shipped.
+function ItemBase:Load()
+  local state = lib._itemBase
+  if state.loaded then
+    return state.data ~= nil
+  end
+
+  local t = locateDataTable()
+  if not t or t.version == "placeholder" or type(t.items) ~= "table" then
+    state.loaded    = true
+    state.available = false
+    state.data      = nil
+    return false
+  end
+
+  state.data      = t
+  state.available = true
+  state.loaded    = true
+  fireReady()
+  return true
+end
+
+-- ----------------------------------------------------------------------------
+-- Public API
+-- ----------------------------------------------------------------------------
+
+-- ResolveName: live client cache wins, static cache fallback.
+-- Returns (itemID, meta) or (nil, nil) when neither resolves the name.
+function ItemBase:ResolveName(name)
+  if type(name) ~= "string" or name == "" then return nil, nil end
+
+  -- Live cache first. C_Item.GetItemInfo accepts a name and returns the
+  -- itemID via its second-to-last return on modern clients; older clients
+  -- expose the same data via GetItemInfoInstant. We try the modern path
+  -- and fall back gracefully.
+  if GetItemInfoInstant then
+    local liveID = select(1, GetItemInfoInstant(name))
+    if type(liveID) == "number" and liveID > 0 then
+      local meta = self:GetItem(liveID)
+      return liveID, meta
+    end
+  end
+
+  -- Static cache.
+  if not self:Load() then return nil, nil end
+  local data = lib._itemBase.data
+  local byName = data and data.byName
+  if type(byName) ~= "table" then return nil, nil end
+  local id = byName[string.lower(name)]
+  if not id then return nil, nil end
+  return id, data.items and data.items[id] or nil
+end
+
+-- GetItem: itemID -> metadata. Static cache only; does not consult the live
+-- client cache (callers that already have an itemID are usually after the
+-- canonical bundled metadata, not whatever the live cache happened to have
+-- warmed up).
+function ItemBase:GetItem(itemID)
+  if type(itemID) ~= "number" then return nil end
+  if not self:Load() then return nil end
+  local data = lib._itemBase.data
+  if not data or type(data.items) ~= "table" then return nil end
+  return data.items[itemID]
+end
+
+-- ResolveNames: bulk variant of ResolveName for import flows. Returns a
+-- parallel array of { itemID, meta } entries, or `false` for unresolved
+-- positions (using `false` instead of nil keeps array length stable for
+-- consumers that iterate with ipairs).
+function ItemBase:ResolveNames(names)
+  if type(names) ~= "table" then return {} end
+  local out = {}
+  for i = 1, #names do
+    local id, meta = self:ResolveName(names[i])
+    if id then
+      out[i] = { itemID = id, meta = meta }
+    else
+      out[i] = false
+    end
+  end
+  return out
+end
+
+-- IsAvailable: does a non-placeholder data file exist? Cheap probe; safe to
+-- call before Load(). Cogs use this to decide whether to surface "Item base
+-- ready" UI affordances.
+function ItemBase:IsAvailable()
+  local state = lib._itemBase
+  if state.available == nil then
+    state.available = probeAvailable()
+  end
+  return state.available
+end
+
+-- IsLoaded: has the lazy parse already happened? (Distinct from IsAvailable,
+-- which just checks file presence.)
+function ItemBase:IsLoaded()
+  return lib._itemBase.loaded == true
+end
+
+-- Version: WoW build + ISO-8601 generation timestamp from the data file, or
+-- nil when the data file is absent. Cogs surface this on About panels.
+function ItemBase:Version()
+  if not self:Load() then return nil, nil end
+  local data = lib._itemBase.data
+  if not data then return nil, nil end
+  return data.version, data.generatedAt
+end
+
+-- Stats: { items = N, byName = N, locale = "enUS" } for diagnostic surfaces.
+-- Returns nil when the data file is absent so callers can branch cleanly.
+function ItemBase:Stats()
+  if not self:Load() then return nil end
+  local data = lib._itemBase.data
+  if not data then return nil end
+  local nItems, nByName = 0, 0
+  if type(data.items) == "table" then
+    for _ in pairs(data.items) do nItems = nItems + 1 end
+  end
+  if type(data.byName) == "table" then
+    for _ in pairs(data.byName) do nByName = nByName + 1 end
+  end
+  return {
+    items  = nItems,
+    byName = nByName,
+    locale = data.locale,
+  }
+end
+
+-- OnReady: fire `cb` once the lazy parse completes successfully. If the data
+-- file is already loaded (or already known absent), the callback fires right
+-- away — synchronously when loaded, never when absent (we don't fire failure
+-- callbacks; consumers should pair OnReady with IsAvailable for that signal).
+function ItemBase:OnReady(cb)
+  if type(cb) ~= "function" then return end
+  if lib._itemBase.loaded then
+    if lib._itemBase.data then
+      pcall(cb)
+    end
+    return
+  end
+  table.insert(lib._itemBase.readyCbs, cb)
+end

--- a/tools/generate-item-base.py
+++ b/tools/generate-item-base.py
@@ -112,6 +112,29 @@ ITEM_PATH_FMT = "/data/wow/item/{item_id}"
 # if every item ID 404s.
 VERSION_FALLBACK = "unknown"
 
+# Valid Blizzard Game Data API locale codes (underscore form). WoW client-side
+# locale codes (`enUS`, `deDE`, …) are the CLI/TOC convention, so we accept those
+# and translate at the API boundary. Sending an unknown locale causes Blizzard
+# to return localized strings as a `{en_US: "...", de_DE: "..."}` dict instead
+# of the flat string we want; v1 of this script crashed on that dict at the
+# `.lower()` call further down.
+_API_LOCALES = {
+    "enUS": "en_US", "esMX": "es_MX", "ptBR": "pt_BR", "deDE": "de_DE",
+    "enGB": "en_GB", "esES": "es_ES", "frFR": "fr_FR", "itIT": "it_IT",
+    "ruRU": "ru_RU", "koKR": "ko_KR", "zhTW": "zh_TW", "zhCN": "zh_CN",
+}
+
+
+def api_locale(wow_locale: str) -> str:
+    """Translate a WoW client locale code to the Blizzard API form."""
+    if wow_locale in _API_LOCALES:
+        return _API_LOCALES[wow_locale]
+    # Pass-through for already-correct (`en_US`) input.
+    if wow_locale in _API_LOCALES.values():
+        return wow_locale
+    raise SystemExit(f"unknown locale: {wow_locale!r}; expected one of {sorted(_API_LOCALES)}")
+
+
 # Pattern for the resolved namespace embedded in `_links.self.href`:
 #   .../data/wow/item/6948?namespace=static-12.0.5_60000-us&locale=enUS
 # captures (1) the dotted patch and (2) the build number.
@@ -178,7 +201,7 @@ class BlizzardClient:
         self._ensure_token()
         self._throttle()
         path = ITEM_PATH_FMT.format(item_id=item_id)
-        query = urllib.parse.urlencode({"namespace": self.namespace, "locale": locale})
+        query = urllib.parse.urlencode({"namespace": self.namespace, "locale": api_locale(locale)})
         url = f"{self.host}{path}?{query}"
         backoff = 1.0
         for attempt in range(5):

--- a/tools/generate-item-base.py
+++ b/tools/generate-item-base.py
@@ -16,6 +16,11 @@ CLI:
     --end-id    N                  Resume cursor: highest itemID to scan (default 250000).
     --out-path  PATH               Output file path (default Cogworks-1.0/Data/ItemBase-Generated-<locale>.lua).
     --region    {us,eu,kr,tw,cn}   Blizzard API region (default us).
+    --rps       N                  Max global request rate (default 25). Hard ceiling enforced
+                                   by a thread-safe slot reservation across workers.
+    --workers   N                  Concurrent HTTP workers (default 8). One worker tops out at
+                                   ~5.5 req/sec because of per-request RTT (~180ms); parallel
+                                   workers scale linearly until --rps becomes the bottleneck.
     --dry-run                      Print stats but don't write the output file.
 
 Filtering heuristic (issue #28):
@@ -64,9 +69,10 @@ Usage example:
 Notes:
     * Stdlib only (urllib + json) — no `requests` dependency, so the script
       runs in CI / contributor envs without a venv setup step.
-    * Polite to the API: bounded request concurrency (default 25 rps), retries
-      with backoff on 429 / 5xx, and an OAuth token-refresh path. The token
-      Blizzard hands out is good for ~24h; we refresh on 401.
+    * Polite to the API: thread-pool of HTTP workers (default 8) with a
+      global rate-cap reservation, retries with backoff on 429 / 5xx, and an
+      OAuth token-refresh path. The token Blizzard hands out is good for ~24h;
+      we refresh on 401.
     * The script is intentionally idempotent: a re-run on the same range
       produces a byte-identical Lua file given the same upstream data.
 """
@@ -75,11 +81,13 @@ from __future__ import annotations
 
 import argparse
 import base64
+import concurrent.futures
 import datetime as dt
 import json
 import os
 import re
 import sys
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -97,6 +105,9 @@ DEFAULT_REGION = "us"
 DEFAULT_START_ID = 1
 DEFAULT_END_ID = 250_000  # Sane upper bound; WoW item ID space sits well below this.
 DEFAULT_RPS = 25  # Stay well under Blizzard's 100 req/sec free-tier ceiling.
+DEFAULT_WORKERS = 8  # Concurrent HTTP workers. Per-request RTT is ~180ms, so a
+                     # single worker tops out at ~5.5 req/sec regardless of --rps.
+                     # 8 workers × ~5 req/sec ≈ 40 req/sec global, well under cap.
 
 # OAuth: client-credentials flow, region-specific endpoint.
 TOKEN_ENDPOINT_FMT = "https://oauth.battle.net/token"
@@ -162,6 +173,9 @@ class BlizzardClient:
         # Captured from the first 200 response's resolved namespace. Stays None
         # until we get a real item back; main() falls back to VERSION_FALLBACK.
         self.resolved_version: str | None = None
+        # One lock guards token rotation, resolved_version capture, and throttle
+        # slot reservation. Critical sections are brief so a single lock is fine.
+        self._lock = threading.Lock()
 
     # -- token ----------------------------------------------------------------
 
@@ -185,16 +199,27 @@ class BlizzardClient:
         self._token_expires_at = time.time() + int(payload["expires_in"]) - 60
 
     def _ensure_token(self) -> None:
-        if self._token is None or time.time() >= self._token_expires_at:
-            self._fetch_token()
+        # Fast path: read without locking; safe because _token is replaced
+        # atomically. Slow path: lock + re-check + refresh.
+        if self._token is not None and time.time() < self._token_expires_at:
+            return
+        with self._lock:
+            if self._token is None or time.time() >= self._token_expires_at:
+                self._fetch_token()
 
     # -- requests -------------------------------------------------------------
 
     def _throttle(self) -> None:
-        gap = time.time() - self._last_call
-        if gap < self.min_interval:
-            time.sleep(self.min_interval - gap)
-        self._last_call = time.time()
+        # Thread-safe slot reservation: under the lock, claim the next legal
+        # call time. Then sleep outside the lock so other workers can claim
+        # their own slots in parallel — staggered by min_interval globally.
+        with self._lock:
+            now = time.time()
+            slot = max(self._last_call + self.min_interval, now)
+            self._last_call = slot
+            sleep_for = slot - now
+        if sleep_for > 0:
+            time.sleep(sleep_for)
 
     def get_item(self, item_id: int, locale: str) -> dict[str, Any] | None:
         """Return the parsed item JSON, or None for 404 (item ID not assigned)."""
@@ -216,6 +241,8 @@ class BlizzardClient:
                     href = ((payload.get("_links") or {}).get("self") or {}).get("href", "")
                     m = _NAMESPACE_RE.search(href)
                     if m:
+                        # Last-writer-wins is fine; every response yields the
+                        # same string. No lock needed.
                         self.resolved_version = f"{m.group(1)}.{m.group(2)}"
                 return payload
             except urllib.error.HTTPError as exc:
@@ -350,7 +377,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument("--region", default=DEFAULT_REGION, choices=["us", "eu", "kr", "tw", "cn"])
     p.add_argument("--start-id", type=int, default=DEFAULT_START_ID)
     p.add_argument("--end-id", type=int, default=DEFAULT_END_ID)
-    p.add_argument("--rps", type=int, default=DEFAULT_RPS)
+    p.add_argument("--rps", type=int, default=DEFAULT_RPS,
+                   help=f"Max global request rate (default {DEFAULT_RPS}). Real ceiling is "
+                        "min(--rps, --workers / per-request-RTT); RTT is ~180ms.")
+    p.add_argument("--workers", type=int, default=DEFAULT_WORKERS,
+                   help=f"Number of concurrent HTTP workers (default {DEFAULT_WORKERS}). "
+                        "At ~180ms RTT, one worker is ~5.5 req/sec; 8 workers ≈ 40 req/sec.")
     p.add_argument("--out-path", type=Path, default=None,
                    help="Override output file. Default: Cogworks-1.0/Data/ItemBase-Generated-<locale>.lua")
     p.add_argument("--dry-run", action="store_true",
@@ -378,23 +410,38 @@ def main(argv: list[str]) -> int:
     seen = 0
     kept = 0
 
-    for item_id in range(args.start_id, args.end_id + 1):
-        seen += 1
+    # Workers do the network I/O; main thread does the deterministic merge so
+    # the collision policy (highest-quality + highest-id wins) doesn't depend
+    # on completion order. Workers return (item_id, normalized_entry_or_None);
+    # entries that are None mean 404 / filtered / fetch-error.
+    def fetch_one(item_id: int) -> tuple[int, dict[str, Any] | None]:
         try:
             raw = client.get_item(item_id, args.locale)
         except Exception as exc:  # noqa: BLE001
             print(f"WARN: item {item_id} fetch failed: {exc}", file=sys.stderr)
-            continue
-        if raw is None:
-            continue
-        if not is_tradeable(raw):
-            continue
-        entry = normalize(raw)
-        items[item_id] = entry
-        kept += 1
+            return (item_id, None)
+        if raw is None or not is_tradeable(raw):
+            return (item_id, None)
+        return (item_id, normalize(raw))
 
-        # byName: lowercased name -> primary itemID.
-        # Collision policy v1: highest-quality + most-recent wins (latter clobbers).
+    fetched: list[tuple[int, dict[str, Any]]] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = (pool.submit(fetch_one, i)
+                   for i in range(args.start_id, args.end_id + 1))
+        for fut in concurrent.futures.as_completed(list(futures)):
+            item_id, entry = fut.result()
+            seen += 1
+            if entry is not None:
+                fetched.append((item_id, entry))
+                kept += 1
+            if seen % 1000 == 0:
+                print(f"... scanned {seen} ids, kept {kept}", file=sys.stderr)
+
+    # Deterministic merge: process in item-id order so the "latter wins on tie"
+    # half of the collision policy is reproducible across runs.
+    fetched.sort(key=lambda t: t[0])
+    for item_id, entry in fetched:
+        items[item_id] = entry
         name = (entry.get("name") or "").lower()
         if not name:
             continue
@@ -405,9 +452,6 @@ def main(argv: list[str]) -> int:
             prev_q = items[prev_id]["q"]
             if entry["q"] > prev_q or (entry["q"] == prev_q and item_id > prev_id):
                 by_name[name] = item_id
-
-        if seen % 1000 == 0:
-            print(f"... scanned {seen} ids, kept {kept}", file=sys.stderr)
 
     table = {
         "version": client.resolved_version or VERSION_FALLBACK,

--- a/tools/generate-item-base.py
+++ b/tools/generate-item-base.py
@@ -104,11 +104,18 @@ GAMEDATA_HOST_FMT = "https://{region}.api.blizzard.com"
 ITEM_NAMESPACE_FMT = "static-{region}"
 ITEM_PATH_FMT = "/data/wow/item/{item_id}"
 
-# A WoW build/patch we tag the file with. Pulled from /data/wow/keystone-affix
-# or similar version-bearing endpoint at runtime; falls back to "unknown" so
-# the generator always produces a well-formed file even if Blizzard's version
-# manifest is down.
+# A WoW build/patch we tag the file with. We extract this from the resolved
+# namespace Blizzard returns on the first 200 response — the API takes our
+# `namespace=static-us` query and resolves it to a build-specific namespace
+# like `static-12.0.5_60000-us` in the response's `_links.self.href`. Falls
+# back to "unknown" so the generator always produces a well-formed file even
+# if every item ID 404s.
 VERSION_FALLBACK = "unknown"
+
+# Pattern for the resolved namespace embedded in `_links.self.href`:
+#   .../data/wow/item/6948?namespace=static-12.0.5_60000-us&locale=enUS
+# captures (1) the dotted patch and (2) the build number.
+_NAMESPACE_RE = re.compile(r"namespace=static-(\d+(?:\.\d+)*)_(\d+)-[a-z]+")
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +136,9 @@ class BlizzardClient:
         self._last_call = 0.0
         self._token: str | None = None
         self._token_expires_at: float = 0.0
+        # Captured from the first 200 response's resolved namespace. Stays None
+        # until we get a real item back; main() falls back to VERSION_FALLBACK.
+        self.resolved_version: str | None = None
 
     # -- token ----------------------------------------------------------------
 
@@ -178,7 +188,13 @@ class BlizzardClient:
             )
             try:
                 with urllib.request.urlopen(req, timeout=30) as resp:
-                    return json.load(resp)
+                    payload = json.load(resp)
+                if self.resolved_version is None:
+                    href = ((payload.get("_links") or {}).get("self") or {}).get("href", "")
+                    m = _NAMESPACE_RE.search(href)
+                    if m:
+                        self.resolved_version = f"{m.group(1)}.{m.group(2)}"
+                return payload
             except urllib.error.HTTPError as exc:
                 if exc.code == 404:
                     return None
@@ -371,7 +387,7 @@ def main(argv: list[str]) -> int:
             print(f"... scanned {seen} ids, kept {kept}", file=sys.stderr)
 
     table = {
-        "version": VERSION_FALLBACK,  # TODO(COG-28): pull a real WoW patch.build from /data/wow/...
+        "version": client.resolved_version or VERSION_FALLBACK,
         "generatedAt": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "locale": args.locale,
         "items": items,

--- a/tools/generate-item-base.py
+++ b/tools/generate-item-base.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Generate Cogworks-1.0/Data/ItemBase-Generated-<locale>.lua from Blizzard's WoW Game Data API.
+
+This script fetches OAuth-authenticated metadata for AH-tradeable items from
+Blizzard's Game Data API, normalises it into the schema described in
+gezmodean-wow/cogworks#28, and writes a Lua `return { ... }` table that ships
+inside the Cogworks-1.0 library directory.
+
+Inputs (env):
+    BNET_CLIENT_ID, BNET_CLIENT_SECRET   -- Blizzard developer OAuth credentials.
+                                            Free tier: 100 req/sec, 36k req/hour.
+
+CLI:
+    --locale {enUS,deDE,frFR,...}  Locale to fetch (default enUS).
+    --start-id  N                  Resume cursor: lowest itemID to scan (default 1).
+    --end-id    N                  Resume cursor: highest itemID to scan (default 250000).
+    --out-path  PATH               Output file path (default Cogworks-1.0/Data/ItemBase-Generated-<locale>.lua).
+    --region    {us,eu,kr,tw,cn}   Blizzard API region (default us).
+    --dry-run                      Print stats but don't write the output file.
+
+Filtering heuristic (issue #28):
+    quality >= 1                   "salable_quality" — drops poor-quality vendor trash.
+    NOT soulbound                  inventory_type / preview_item flags exclude bind-on-pickup.
+    Tradeable on the AH            if Blizzard's preview_item.binding == "Binds when picked up"
+                                   we drop it; "Binds when equipped" / "Binds to account" / unbound
+                                   are kept.
+
+Output schema (per issue #28):
+    The file assigns the table to a per-locale global so Cogworks-1.0/ItemBase.lua
+    can pick it up after the XML manifest evaluates the data file (WoW's XML
+    script loader doesn't surface a chunk's `return` value, hence the global
+    handshake).
+
+    CogworksItemBaseData_enUS = {
+        version     = "<wow patch>.<build>",
+        generatedAt = "<ISO-8601 UTC>",
+        locale      = "enUS",
+        items = {
+            [12345] = {
+                name      = "Itemname",
+                q         = 4,
+                ilvl      = 100,
+                xpac      = 11,
+                tier      = 0,
+                invType   = 1,
+                subClass  = 0,
+            },
+        },
+        byName = {
+            ["itemname"] = 12345,
+        },
+    }
+
+Usage example:
+    BNET_CLIENT_ID=... BNET_CLIENT_SECRET=... \\
+        python tools/generate-item-base.py --locale enUS
+
+    # Resume after a partial run:
+    python tools/generate-item-base.py --locale enUS --start-id 80000
+
+    # Smoke test without writing:
+    python tools/generate-item-base.py --dry-run --end-id 1000
+
+Notes:
+    * Stdlib only (urllib + json) — no `requests` dependency, so the script
+      runs in CI / contributor envs without a venv setup step.
+    * Polite to the API: bounded request concurrency (default 25 rps), retries
+      with backoff on 429 / 5xx, and an OAuth token-refresh path. The token
+      Blizzard hands out is good for ~24h; we refresh on 401.
+    * The script is intentionally idempotent: a re-run on the same range
+      produces a byte-identical Lua file given the same upstream data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as dt
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_LOCALE = "enUS"
+DEFAULT_REGION = "us"
+DEFAULT_START_ID = 1
+DEFAULT_END_ID = 250_000  # Sane upper bound; WoW item ID space sits well below this.
+DEFAULT_RPS = 25  # Stay well under Blizzard's 100 req/sec free-tier ceiling.
+
+# OAuth: client-credentials flow, region-specific endpoint.
+TOKEN_ENDPOINT_FMT = "https://oauth.battle.net/token"
+GAMEDATA_HOST_FMT = "https://{region}.api.blizzard.com"
+ITEM_NAMESPACE_FMT = "static-{region}"
+ITEM_PATH_FMT = "/data/wow/item/{item_id}"
+
+# A WoW build/patch we tag the file with. Pulled from /data/wow/keystone-affix
+# or similar version-bearing endpoint at runtime; falls back to "unknown" so
+# the generator always produces a well-formed file even if Blizzard's version
+# manifest is down.
+VERSION_FALLBACK = "unknown"
+
+
+# ---------------------------------------------------------------------------
+# OAuth + HTTP plumbing
+# ---------------------------------------------------------------------------
+
+
+class BlizzardClient:
+    """Thin OAuth-authenticated HTTP client for the WoW Game Data API."""
+
+    def __init__(self, client_id: str, client_secret: str, region: str, rps: int):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.region = region
+        self.host = GAMEDATA_HOST_FMT.format(region=region)
+        self.namespace = ITEM_NAMESPACE_FMT.format(region=region)
+        self.min_interval = 1.0 / max(1, rps)
+        self._last_call = 0.0
+        self._token: str | None = None
+        self._token_expires_at: float = 0.0
+
+    # -- token ----------------------------------------------------------------
+
+    def _fetch_token(self) -> None:
+        creds = f"{self.client_id}:{self.client_secret}".encode()
+        auth = base64.b64encode(creds).decode()
+        body = urllib.parse.urlencode({"grant_type": "client_credentials"}).encode()
+        req = urllib.request.Request(
+            TOKEN_ENDPOINT_FMT,
+            data=body,
+            headers={
+                "Authorization": f"Basic {auth}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+        self._token = payload["access_token"]
+        # `expires_in` is seconds. Refresh 60s before the wall.
+        self._token_expires_at = time.time() + int(payload["expires_in"]) - 60
+
+    def _ensure_token(self) -> None:
+        if self._token is None or time.time() >= self._token_expires_at:
+            self._fetch_token()
+
+    # -- requests -------------------------------------------------------------
+
+    def _throttle(self) -> None:
+        gap = time.time() - self._last_call
+        if gap < self.min_interval:
+            time.sleep(self.min_interval - gap)
+        self._last_call = time.time()
+
+    def get_item(self, item_id: int, locale: str) -> dict[str, Any] | None:
+        """Return the parsed item JSON, or None for 404 (item ID not assigned)."""
+        self._ensure_token()
+        self._throttle()
+        path = ITEM_PATH_FMT.format(item_id=item_id)
+        query = urllib.parse.urlencode({"namespace": self.namespace, "locale": locale})
+        url = f"{self.host}{path}?{query}"
+        backoff = 1.0
+        for attempt in range(5):
+            req = urllib.request.Request(
+                url,
+                headers={"Authorization": f"Bearer {self._token}"},
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    return json.load(resp)
+            except urllib.error.HTTPError as exc:
+                if exc.code == 404:
+                    return None
+                if exc.code == 401:
+                    # Token rotated under us; refresh and retry once.
+                    self._fetch_token()
+                    continue
+                if exc.code in (429, 500, 502, 503, 504):
+                    time.sleep(backoff)
+                    backoff = min(backoff * 2, 30)
+                    continue
+                raise
+            except urllib.error.URLError:
+                time.sleep(backoff)
+                backoff = min(backoff * 2, 30)
+                continue
+        # Five strikes and the item ID is out for this run; caller can resume.
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Item normalisation + filtering
+# ---------------------------------------------------------------------------
+
+
+def is_tradeable(item: dict[str, Any]) -> bool:
+    """Heuristic from issue #28: quality >= 1 AND not soulbound."""
+    quality = item.get("quality") or {}
+    quality_type = quality.get("type", "")
+    # Blizzard surfaces quality as POOR / COMMON / UNCOMMON / RARE / EPIC / LEGENDARY / ARTIFACT / HEIRLOOM.
+    if quality_type in ("", "POOR"):
+        return False
+    preview = item.get("preview_item") or {}
+    binding = (preview.get("binding") or {}).get("type", "")
+    # Soulbound items can't go on the AH; drop them.
+    if binding == "ON_ACQUIRE":  # "Binds when picked up"
+        return False
+    return True
+
+
+_QUALITY_ENUM = {
+    "POOR": 0, "COMMON": 1, "UNCOMMON": 2, "RARE": 3, "EPIC": 4,
+    "LEGENDARY": 5, "ARTIFACT": 6, "HEIRLOOM": 7,
+}
+
+
+def normalize(item: dict[str, Any]) -> dict[str, Any]:
+    """Coerce the Blizzard JSON into the cogworks ItemBase entry schema."""
+    quality = item.get("quality") or {}
+    inv_type = item.get("inventory_type") or {}
+    item_class = item.get("item_class") or {}
+    item_subclass = item.get("item_subclass") or {}
+    return {
+        "name": item.get("name", ""),
+        "q": _QUALITY_ENUM.get(quality.get("type", ""), 0),
+        "ilvl": int(item.get("level", 0) or 0),
+        "xpac": int((item.get("expansion") or {}).get("id", 0) or 0),
+        "tier": 0,  # PBS tier mapping; left at 0 until inventoryType -> tier table is wired in.
+        "invType": int(inv_type.get("id", 0) or 0),
+        "subClass": int(item_subclass.get("id", 0) or 0),
+        "_class": int(item_class.get("id", 0) or 0),  # internal, dropped in serializer
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lua serialisation
+# ---------------------------------------------------------------------------
+
+
+_LUA_KEY_OK = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def lua_string(s: str) -> str:
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n") + '"'
+
+
+def lua_key(k: str) -> str:
+    if _LUA_KEY_OK.match(k):
+        return k
+    return f"[{lua_string(k)}]"
+
+
+def write_lua(out_path: Path, table: dict[str, Any]) -> None:
+    """Emit a deterministic, sorted Lua `return { ... }` file."""
+    items: dict[int, dict[str, Any]] = table["items"]
+    by_name: dict[str, int] = table["byName"]
+
+    lines: list[str] = []
+    lines.append("-- AUTO-GENERATED. Regenerate via tools/generate-item-base.py.")
+    lines.append("-- DO NOT EDIT BY HAND.")
+    lines.append(f"CogworksItemBaseData_{table['locale']} = {{")
+    lines.append(f"  version     = {lua_string(table['version'])},")
+    lines.append(f"  generatedAt = {lua_string(table['generatedAt'])},")
+    lines.append(f"  locale      = {lua_string(table['locale'])},")
+    lines.append("  items = {")
+    for item_id in sorted(items.keys()):
+        e = items[item_id]
+        # Strip internal-only fields.
+        e = {k: v for k, v in e.items() if not k.startswith("_")}
+        parts = []
+        for k in ("name", "q", "ilvl", "xpac", "tier", "invType", "subClass"):
+            if k not in e:
+                continue
+            v = e[k]
+            v_str = lua_string(v) if isinstance(v, str) else str(v)
+            parts.append(f"{k}={v_str}")
+        lines.append(f"    [{item_id}]={{ {', '.join(parts)} }},")
+    lines.append("  },")
+    lines.append("  byName = {")
+    for name in sorted(by_name.keys()):
+        lines.append(f"    [{lua_string(name)}]={by_name[name]},")
+    lines.append("  },")
+    lines.append("}")
+    lines.append("")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parent.parent
+    default_out = repo_root / "Cogworks-1.0" / "Data"
+
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--locale", default=DEFAULT_LOCALE)
+    p.add_argument("--region", default=DEFAULT_REGION, choices=["us", "eu", "kr", "tw", "cn"])
+    p.add_argument("--start-id", type=int, default=DEFAULT_START_ID)
+    p.add_argument("--end-id", type=int, default=DEFAULT_END_ID)
+    p.add_argument("--rps", type=int, default=DEFAULT_RPS)
+    p.add_argument("--out-path", type=Path, default=None,
+                   help="Override output file. Default: Cogworks-1.0/Data/ItemBase-Generated-<locale>.lua")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Don't write the output file; report stats only.")
+    args = p.parse_args(argv)
+    if args.out_path is None:
+        args.out_path = default_out / f"ItemBase-Generated-{args.locale}.lua"
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    client_id = os.environ.get("BNET_CLIENT_ID")
+    client_secret = os.environ.get("BNET_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        print("ERROR: BNET_CLIENT_ID and BNET_CLIENT_SECRET must be set in the environment.",
+              file=sys.stderr)
+        return 2
+
+    client = BlizzardClient(client_id, client_secret, args.region, args.rps)
+
+    items: dict[int, dict[str, Any]] = {}
+    by_name: dict[str, int] = {}
+    seen = 0
+    kept = 0
+
+    for item_id in range(args.start_id, args.end_id + 1):
+        seen += 1
+        try:
+            raw = client.get_item(item_id, args.locale)
+        except Exception as exc:  # noqa: BLE001
+            print(f"WARN: item {item_id} fetch failed: {exc}", file=sys.stderr)
+            continue
+        if raw is None:
+            continue
+        if not is_tradeable(raw):
+            continue
+        entry = normalize(raw)
+        items[item_id] = entry
+        kept += 1
+
+        # byName: lowercased name -> primary itemID.
+        # Collision policy v1: highest-quality + most-recent wins (latter clobbers).
+        name = (entry.get("name") or "").lower()
+        if not name:
+            continue
+        prev_id = by_name.get(name)
+        if prev_id is None:
+            by_name[name] = item_id
+        else:
+            prev_q = items[prev_id]["q"]
+            if entry["q"] > prev_q or (entry["q"] == prev_q and item_id > prev_id):
+                by_name[name] = item_id
+
+        if seen % 1000 == 0:
+            print(f"... scanned {seen} ids, kept {kept}", file=sys.stderr)
+
+    table = {
+        "version": VERSION_FALLBACK,  # TODO(COG-28): pull a real WoW patch.build from /data/wow/...
+        "generatedAt": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "locale": args.locale,
+        "items": items,
+        "byName": by_name,
+    }
+
+    print(f"scanned={seen} kept={kept} unique-names={len(by_name)}", file=sys.stderr)
+
+    if args.dry_run:
+        print("dry-run: not writing output", file=sys.stderr)
+        return 0
+
+    write_lua(args.out_path, table)
+    print(f"wrote {args.out_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- Scaffolds the cogworks-side `cw.ItemBase` loader so sibling cogs (FlipQueue, Tally, Maxcraft) can resolve item names the live WoW cache hasn't seen — the gap that imports from FlippingPal / TSM / PBS hit today
- Ships a **placeholder** data file so the loader API can land first; consumer cogs can wire up `IsAvailable()` checks while the real ~3 MB generated table lands in a follow-up
- Drafts `tools/generate-item-base.py` — stdlib-only Python 3 build script (OAuth client credentials, throttled, retries on 429/5xx, resumable via `--start-id`/`--end-id`) for the Blizzard Game Data API pipeline

Bumps `lib.minorVersion` 19 → 20. New ItemBase module at MODULE_MINOR=1. CHANGELOG `## Unreleased` opened.

Draft because the data file is intentionally a placeholder — kept open until the generator runs against the real API and the bundled `Data/ItemBase-Generated-enUS.lua` is committed on top.

## Test plan
- [ ] `/reload` Cogworks Standalone with the placeholder data file present — no parse errors
- [ ] `cw.ItemBase:IsAvailable()` returns `false` against the placeholder
- [ ] `cw.ItemBase:ResolveName("anything")` returns `nil, nil` cleanly when only the placeholder is present
- [ ] `cw.ItemBase:OnReady(cb)` does not fire while the data file is a placeholder
- [ ] `python tools/generate-item-base.py --help` parses CLI args without runtime error
- [ ] Once the generator has run, swap the placeholder for the real `Data/ItemBase-Generated-enUS.lua` and re-run `IsAvailable() / Stats() / ResolveName()` against a known imported item

Refs #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)