### PR TITLE
fix(COG-56): CreateDebugConsole crash from eager tab activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Cogworks-1.0 are tracked here. The library is **additive only** — old APIs never disappear, so every entry below is something gained, never lost.
 
+## Unreleased
+
+- fix(COG-56): CreateDebugConsole crashed with "attempt to call a nil value" because TabPanel's eager initial activation fired tab `build` closures that reference `f._buildActions` / `_buildInspectors` / `_buildProfile` / `_buildLog` before those methods are defined further down in `CreateDebugConsole`. TabPanel gains an additive `lazy = true` opt (MODULE_MINOR `15 → 16`) that suppresses the auto-activate; Debug.lua passes it and now calls `panel:SetActiveTab(...)` once every builder is wired (MODULE_MINOR `1 → 2`). Bumps lib MINOR `19 → 20`.
+
 ## [0.13.2] — 2026-05-05 — Critical: StaticPopupDialogs taint hotfix (COG-30)
 
 Bumps MINOR from `18` to `19`. Hotfix for a long-latent taint introduced in v0.12.0 that blocked the player from right-clicking certain bag items (most visibly knowledge tomes and consumables that show a confirmation prompt on use).

--- a/Cogworks-1.0/Cogworks-1.0.lua
+++ b/Cogworks-1.0/Cogworks-1.0.lua
@@ -25,7 +25,7 @@ assert(LibStub:GetLibrary("CallbackHandler-1.0", true), "Cogworks-1.0 requires C
 -- because every consumer ships the same external, the path resolves either way.
 local LIB_LOADER_ADDON = ...
 
-local MAJOR, MINOR = "Cogworks-1.0", 19
+local MAJOR, MINOR = "Cogworks-1.0", 20
 local lib, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end  -- already loaded at this version or newer
 oldminor = oldminor or 0

--- a/Cogworks-1.0/Debug.lua
+++ b/Cogworks-1.0/Debug.lua
@@ -30,7 +30,7 @@
 local lib = LibStub("Cogworks-1.0")
 if not lib then return end
 
-local MODULE_MINOR = 1
+local MODULE_MINOR = 2
 lib._modules = lib._modules or {}
 if (lib._modules.Debug or 0) >= MODULE_MINOR then return end
 lib._modules.Debug = MODULE_MINOR
@@ -513,7 +513,13 @@ function lib:CreateDebugConsole(opts)
   tabHost:SetPoint("TOPLEFT",     statusRow, "BOTTOMLEFT",  0, -2)
   tabHost:SetPoint("BOTTOMRIGHT", f,         "BOTTOMRIGHT", -4, 14)
 
+  -- The tab build closures reference f._buildActions / f._buildInspectors /
+  -- f._buildProfile / f._buildLog — all defined further down in this function.
+  -- TabPanel's eager initial activation would fire those closures before the
+  -- methods exist, so we pass lazy=true here and explicitly activate the
+  -- starting tab at the bottom of CreateDebugConsole once everything is wired.
   local panel = self:CreateTabPanel(tabHost, {
+    lazy = true,
     tabs = {
       { key = "actions",    label = "Actions",    build = function(p) f._buildActions(p)    end },
       { key = "inspectors", label = "Inspectors", build = function(p) f._buildInspectors(p) end },
@@ -835,6 +841,10 @@ function lib:CreateDebugConsole(opts)
     if f._actionsTab and f._actionsTab._rebuild then f._actionsTab._rebuild() end
     f._refreshStatus()
   end
+
+  -- Activate the starting tab now that every f._build* method is defined.
+  -- Honours opts.initialTab if the caller picked a specific landing tab.
+  panel:SetActiveTab(opts.initialTab or "actions")
 
   return f
 end

--- a/Cogworks-1.0/TabPanel.lua
+++ b/Cogworks-1.0/TabPanel.lua
@@ -37,7 +37,7 @@ local lib = LibStub("Cogworks-1.0")
 if not lib then return end
 
 -- Module load guard. See Sections.lua for rationale.
-local MODULE_MINOR = 15
+local MODULE_MINOR = 16
 lib._modules = lib._modules or {}
 if (lib._modules.TabPanel or 0) >= MODULE_MINOR then return end
 lib._modules.TabPanel = MODULE_MINOR
@@ -212,8 +212,15 @@ function lib:CreateTabPanel(parent, opts)
   function panel:SetActiveTab(key) setActive(key) end
   function panel:GetActiveTab()    return activeTab end
 
-  -- Initial activation. Defaults to first tab.
-  setActive(opts.initialTab or opts.tabs[1].key)
+  -- Initial activation. Defaults to first tab. Pass `lazy = true` to skip —
+  -- the consumer is expected to call `panel:SetActiveTab(key)` later, after
+  -- wiring up any tab.build closures whose upvalues aren't resolved at
+  -- construction time (typical: a tab's `build` references methods defined
+  -- on the host frame below this call, so they don't exist yet when the
+  -- panel auto-activates the first tab).
+  if not opts.lazy then
+    setActive(opts.initialTab or opts.tabs[1].key)
+  end
 
   return panel
 end


### PR DESCRIPTION
## Summary

Fixes #56. `CreateDebugConsole` crashed with `attempt to call a nil value` on first open because `TabPanel`'s constructor eagerly fires the initial tab's `build` closure, which references `f._buildActions` / `_buildInspectors` / `_buildProfile` / `_buildLog` — methods assigned further down in the same function and therefore still nil at that moment.

## Approach

- `TabPanel.lua` (MODULE_MINOR `15 → 16`) — additive `lazy = true` opt that suppresses the auto-activate. Existing consumers see no behavior change.
- `Debug.lua` (MODULE_MINOR `1 → 2`) — passes `lazy = true` and calls `panel:SetActiveTab(opts.initialTab or "actions")` at the bottom of `CreateDebugConsole`, after every `f._build*` upvalue is wired.
- lib MINOR `19 → 20`.

## Player update

A crash that happened the first time the in-game debug console was opened is now fixed. If you've been seeing the console fail to display, update Cogworks and try again.

## Test plan

- [ ] Standalone UIShowcase "Debug console" page opens without error.
- [ ] Initial tab (Actions) renders on first open.
- [ ] Switching to Inspectors / Profile / Log builds each tab lazily as before.
- [ ] Existing `CreateTabPanel` consumer (UIShowcase Tabs page) still works unchanged.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)