### PR TITLE
feat(COG-36): CreateStepper queue-based walkthrough primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Cogworks-1.0 are tracked here. The library is **additive 
 ## Unreleased
 
 - fix(COG-56): CreateDebugConsole crashed with "attempt to call a nil value" because TabPanel's eager initial activation fired tab `build` closures that reference `f._buildActions` / `_buildInspectors` / `_buildProfile` / `_buildLog` before those methods are defined further down in `CreateDebugConsole`. TabPanel gains an additive `lazy = true` opt (MODULE_MINOR `15 → 16`) that suppresses the auto-activate; Debug.lua passes it and now calls `panel:SetActiveTab(...)` once every builder is wired (MODULE_MINOR `1 → 2`). Bumps lib MINOR `19 → 20`.
+- **`lib:CreateStepper(parent, opts)`** (`Cogworks-1.0/Stepper.lua`, COG-36) — queue-based one-at-a-time walkthrough primitive; Wizard's sibling for unknown-length item flows. Caller-defined footer actions, Push during traversal, Skip / Back / Cancel / onComplete. Distinct from `CreateWizard` (fixed-N linear setup with validate gate). Unblocks FlipQueue's Deal Finder migration and FlipQueue #160 (failed-post recovery). Bumps lib MINOR `20 → 21`.
 
 ## [0.13.2] — 2026-05-05 — Critical: StaticPopupDialogs taint hotfix (COG-30)
 

--- a/Cogworks-1.0/Cogworks-1.0.lua
+++ b/Cogworks-1.0/Cogworks-1.0.lua
@@ -25,7 +25,7 @@ assert(LibStub:GetLibrary("CallbackHandler-1.0", true), "Cogworks-1.0 requires C
 -- because every consumer ships the same external, the path resolves either way.
 local LIB_LOADER_ADDON = ...
 
-local MAJOR, MINOR = "Cogworks-1.0", 20
+local MAJOR, MINOR = "Cogworks-1.0", 21
 local lib, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end  -- already loaded at this version or newer
 oldminor = oldminor or 0

--- a/Cogworks-1.0/Cogworks-1.0.xml
+++ b/Cogworks-1.0/Cogworks-1.0.xml
@@ -22,6 +22,7 @@
     <Script file="MiniView.lua" />
     <Script file="Text.lua" />
     <Script file="Wizard.lua" />
+    <Script file="Stepper.lua" />
     <Script file="Tree.lua" />
     <Script file="ReorderableList.lua" />
     <Script file="SegmentedControl.lua" />

--- a/Cogworks-1.0/Stepper.lua
+++ b/Cogworks-1.0/Stepper.lua
@@ -1,0 +1,338 @@
+-- Cogworks-1.0/Stepper.lua | Queue-based one-at-a-time walkthrough primitive.
+--
+-- Wizard's sibling. Where Wizard advances a fixed N-step linear flow with a
+-- validation gate and Previous/Next/Finish/Cancel chrome, Stepper walks an
+-- unknown-length queue of items where the player takes a caller-defined
+-- action on each item, with skip-and-keep-going semantics. The queue can
+-- grow mid-traversal (FlipQueue #160 batches failed posts as the player
+-- macro-spins), and Cancel returns the intact remaining queue so the caller
+-- can stash it and re-show later.
+--
+-- Distinct from Wizard:
+--   * Footer buttons are caller-defined (any actions, any labels).
+--   * No per-step validate gate; the action buttons are always enabled and
+--     the caller does whatever per-item check they want inside onAction.
+--   * Queue is dynamic (Push during traversal), index counts visits.
+--   * Skip records the item in history with action="skip" so Back can
+--     revisit it.
+--
+-- Usage:
+--
+--   local stepper = cw:CreateStepper(parent, {
+--     items       = { ... },                       -- initial queue
+--     title       = "Repost failed listings",      -- static header title
+--     -- titleFor = function(item, ctx) ... end,   -- or per-item title
+--     renderItem  = function(content, item, ctx)
+--       -- caller populates content for this item. ctx = {
+--       --   index       1-based position of this visit (= #history + 1)
+--       --   total       index + (#queue-after-current)  -- grows with Push
+--       --   history     list of { item, action } for prior visits
+--       --   queue       remaining queue snapshot (current at queue[1])
+--       -- }
+--     end,
+--     actions     = {
+--       { key = "skip",     label = "Skip" },
+--       { key = "primary",  label = "Repost", style = "primary" },
+--     },
+--     onAction    = function(actionKey, item, ctx)
+--       -- caller logic. By default the stepper advances after onAction
+--       -- returns; return false to suppress auto-advance (caller will
+--       -- later call stepper:Advance(actionKey) or stepper:Cancel()).
+--     end,
+--     onCancel    = function(remainingItems) ... end,
+--     onComplete  = function() ... end,
+--     showProgress = true,                          -- "3 / 12" in header
+--     showBack    = true,                           -- Back button in footer
+--   })
+--   stepper:SetAllPoints()
+--
+--   stepper:Push(item)         -- append to queue end during traversal
+--   stepper:Skip()              -- advance without firing onAction
+--   stepper:Back()              -- revisit prior item; previous action is in ctx.history
+--   stepper:Refresh()           -- re-render current item (e.g. caller mutated state)
+--   stepper:Advance(actionKey)  -- programmatically complete the current item
+--   stepper:GetRemaining()      -- queue snapshot
+--   stepper:GetCurrent()        -- current item (or nil)
+--   stepper:GetHistory()        -- list of { item, action } records
+--
+-- The stepper does not auto-hide on complete; the caller decides whether
+-- to dismiss, show a "done" message, or re-Push more items.
+
+local lib = LibStub("Cogworks-1.0")
+if not lib then return end
+
+-- Module load guard. See Sections.lua for rationale.
+local MODULE_MINOR = 1
+lib._modules = lib._modules or {}
+if (lib._modules.Stepper or 0) >= MODULE_MINOR then return end
+lib._modules.Stepper = MODULE_MINOR
+
+local HEADER_H        = 36
+local FOOTER_H        = 40
+local FOOTER_BTN_W    = 96
+local FOOTER_BTN_H    = 26
+local FOOTER_BTN_GAP  = 8
+
+local function shallowCopy(t)
+  local out = {}
+  for i = 1, #t do out[i] = t[i] end
+  return out
+end
+
+function lib:CreateStepper(parent, opts)
+  opts = opts or {}
+  assert(type(opts.renderItem) == "function",
+    "CreateStepper: opts.renderItem (function) required")
+  assert(type(opts.actions) == "table" and #opts.actions > 0,
+    "CreateStepper: opts.actions required (at least one action)")
+  for _, a in ipairs(opts.actions) do
+    assert(type(a.key) == "string" and a.key ~= "" and type(a.label) == "string",
+      "CreateStepper: each action needs string key + label")
+  end
+
+  local T = self.Theme
+  local showProgress = opts.showProgress ~= false
+  local showBack     = opts.showBack     ~= false
+
+  local stepper = CreateFrame("Frame", nil, parent)
+
+  -- ---- Header (title + progress) ----------------------------------------
+  local header = CreateFrame("Frame", nil, stepper)
+  header:SetHeight(HEADER_H)
+  header:SetPoint("TOPLEFT")
+  header:SetPoint("TOPRIGHT")
+
+  local titleFs = header:CreateFontString(nil, "OVERLAY")
+  titleFs:SetFontObject(self:GetFont("large") or "GameFontNormalLarge")
+  titleFs:SetPoint("LEFT", header, "LEFT", 12, 0)
+  titleFs:SetPoint("RIGHT", header, "RIGHT", -120, 0)
+  titleFs:SetJustifyH("LEFT")
+  titleFs:SetTextColor(unpack(T.text))
+  titleFs:SetWordWrap(false)
+
+  local progressFs
+  if showProgress then
+    progressFs = header:CreateFontString(nil, "OVERLAY")
+    progressFs:SetFontObject(self:GetFont("normal") or "GameFontNormal")
+    progressFs:SetPoint("RIGHT", header, "RIGHT", -12, 0)
+    progressFs:SetTextColor(unpack(T.textDim))
+  end
+
+  local headerBorder = stepper:CreateTexture(nil, "BACKGROUND")
+  headerBorder:SetHeight(1)
+  headerBorder:SetPoint("TOPLEFT", header, "BOTTOMLEFT", 0, 0)
+  headerBorder:SetPoint("TOPRIGHT", header, "BOTTOMRIGHT", 0, 0)
+  headerBorder:SetColorTexture(unpack(T.border))
+
+  -- ---- Footer (button row) ----------------------------------------------
+  local footer = CreateFrame("Frame", nil, stepper)
+  footer:SetHeight(FOOTER_H)
+  footer:SetPoint("BOTTOMLEFT")
+  footer:SetPoint("BOTTOMRIGHT")
+
+  local footerBorder = stepper:CreateTexture(nil, "BACKGROUND")
+  footerBorder:SetHeight(1)
+  footerBorder:SetPoint("BOTTOMLEFT", footer, "TOPLEFT", 0, 0)
+  footerBorder:SetPoint("BOTTOMRIGHT", footer, "TOPRIGHT", 0, 0)
+  footerBorder:SetColorTexture(unpack(T.border))
+
+  -- ---- Content area -----------------------------------------------------
+  local content = CreateFrame("Frame", nil, stepper)
+  content:SetPoint("TOPLEFT", headerBorder, "BOTTOMLEFT", 0, 0)
+  content:SetPoint("BOTTOMRIGHT", footerBorder, "TOPRIGHT", 0, 0)
+  stepper.content = content
+
+  -- ---- State ------------------------------------------------------------
+  local queue   = {}
+  for i, v in ipairs(opts.items or {}) do queue[i] = v end
+  local history = {}    -- list of { item, action }
+
+  local function makeCtx()
+    return {
+      index   = #history + 1,
+      total   = #history + #queue,
+      history = history,
+      queue   = queue,
+    }
+  end
+
+  local function renderCurrent()
+    local item = queue[1]
+    local ctx = makeCtx()
+    if item == nil then
+      -- Empty state: queue has been exhausted (or never had items). Caller
+      -- gets the bare content frame to draw a "done" message; the stepper
+      -- doesn't auto-hide.
+      ctx.index = #history
+      ctx.total = #history
+    end
+
+    -- Header title (static or per-item)
+    if opts.titleFor then
+      titleFs:SetText(opts.titleFor(item, ctx) or "")
+    else
+      titleFs:SetText(opts.title or "")
+    end
+
+    -- Header progress
+    if progressFs then
+      if ctx.total > 0 then
+        progressFs:SetText(ctx.index .. " / " .. ctx.total)
+      else
+        progressFs:SetText("")
+      end
+    end
+
+    -- Let the caller redraw. Caller owns widget lifecycle inside `content`.
+    opts.renderItem(content, item, ctx)
+  end
+
+  -- ---- Footer buttons (declared after state so handlers can close over it)
+  local cancelBtn = self:CreateButton(footer, opts.cancelLabel or "Cancel",
+    FOOTER_BTN_W, FOOTER_BTN_H, nil)
+  cancelBtn:SetPoint("LEFT", footer, "LEFT", 12, 0)
+
+  local backBtn
+  if showBack then
+    backBtn = self:CreateButton(footer, opts.backLabel or "Back",
+      FOOTER_BTN_W, FOOTER_BTN_H, nil)
+    backBtn:SetPoint("LEFT", cancelBtn, "RIGHT", FOOTER_BTN_GAP, 0)
+  end
+
+  -- Build action buttons right-to-left so opts.actions[#] sits at the
+  -- right edge and opts.actions[1] is the leftmost action.
+  local actionBtns = {}
+  do
+    local rightAnchor = footer
+    local rightPoint  = "RIGHT"
+    local xoff        = -12
+    for i = #opts.actions, 1, -1 do
+      local def = opts.actions[i]
+      local btn = self:CreateButton(footer, def.label,
+        FOOTER_BTN_W, FOOTER_BTN_H, nil)
+      btn:SetPoint("RIGHT", rightAnchor, rightPoint, xoff, 0)
+      if def.style == "primary" then
+        btn:SetBackdropBorderColor(unpack(T.gold))
+      end
+      actionBtns[def.key] = btn
+      rightAnchor = btn
+      rightPoint  = "LEFT"
+      xoff        = -FOOTER_BTN_GAP
+    end
+  end
+
+  -- Track primary-style action keys so we can restore gold border on re-enable.
+  local primaryKeys = {}
+  for _, a in ipairs(opts.actions) do
+    if a.style == "primary" then primaryKeys[a.key] = true end
+  end
+
+  -- ---- Button enable/disable based on queue + history -------------------
+  local function applyButtonState()
+    local hasCurrent = queue[1] ~= nil
+    for key, btn in pairs(actionBtns) do
+      if hasCurrent then
+        btn:EnableMouse(true)
+        btn.text:SetTextColor(unpack(T.text))
+        btn:SetBackdropBorderColor(unpack(primaryKeys[key] and T.gold or T.border))
+      else
+        btn:EnableMouse(false)
+        btn.text:SetTextColor(unpack(T.textDisabled))
+        btn:SetBackdropBorderColor(0.2, 0.2, 0.25, 1)
+      end
+    end
+    if backBtn then
+      if #history > 0 then
+        backBtn:EnableMouse(true)
+        backBtn.text:SetTextColor(unpack(T.text))
+        backBtn:SetBackdropBorderColor(unpack(T.border))
+      else
+        backBtn:EnableMouse(false)
+        backBtn.text:SetTextColor(unpack(T.textDisabled))
+        backBtn:SetBackdropBorderColor(0.2, 0.2, 0.25, 1)
+      end
+    end
+  end
+
+  -- ---- Transitions ------------------------------------------------------
+  local function advance(actionKey)
+    local item = queue[1]
+    if item == nil then return end
+    table.remove(queue, 1)
+    history[#history + 1] = { item = item, action = actionKey }
+    if queue[1] == nil and opts.onComplete then
+      renderCurrent()
+      applyButtonState()
+      opts.onComplete()
+      return
+    end
+    renderCurrent()
+    applyButtonState()
+  end
+
+  -- ---- Public API -------------------------------------------------------
+  function stepper:Push(item)
+    queue[#queue + 1] = item
+    -- Re-render so the progress count updates and an empty/complete state
+    -- restarts with the newly current item (onComplete-then-Push case).
+    renderCurrent()
+    applyButtonState()
+  end
+
+  function stepper:Skip()
+    advance("skip")
+  end
+
+  function stepper:Back()
+    if #history == 0 then return end
+    local last = table.remove(history)
+    table.insert(queue, 1, last.item)
+    renderCurrent()
+    applyButtonState()
+  end
+
+  function stepper:Advance(actionKey)
+    advance(actionKey or "advance")
+  end
+
+  function stepper:Refresh()
+    renderCurrent()
+    applyButtonState()
+  end
+
+  function stepper:Cancel()
+    if opts.onCancel then opts.onCancel(shallowCopy(queue)) end
+  end
+
+  function stepper:GetRemaining() return shallowCopy(queue) end
+  function stepper:GetCurrent()   return queue[1] end
+  function stepper:GetHistory()
+    local out = {}
+    for i, h in ipairs(history) do out[i] = { item = h.item, action = h.action } end
+    return out
+  end
+
+  -- ---- Wire footer handlers --------------------------------------------
+  cancelBtn:SetScript("OnClick", function() stepper:Cancel() end)
+  if backBtn then
+    backBtn:SetScript("OnClick", function() stepper:Back() end)
+  end
+  for key, btn in pairs(actionBtns) do
+    btn:SetScript("OnClick", function()
+      local item = queue[1]
+      if item == nil then return end
+      local ctx = makeCtx()
+      local suppress
+      if opts.onAction then
+        suppress = opts.onAction(key, item, ctx) == false
+      end
+      if not suppress then advance(key) end
+    end)
+  end
+
+  -- ---- Initial paint ----------------------------------------------------
+  renderCurrent()
+  applyButtonState()
+
+  return stepper
+end

--- a/Standalone/UIShowcase.lua
+++ b/Standalone/UIShowcase.lua
@@ -1957,9 +1957,9 @@ pages.stepper = function(parent)
           return
         end
 
-        itemFs:SetText(item.name .. "  ×" .. item.count)
+        itemFs:SetText(item.name .. "  x" .. item.count)
         local last = ctx.history[#ctx.history]
-        local lastTxt = last and ("last: " .. last.item.name .. " → " .. last.action)
+        local lastTxt = last and ("last: " .. last.item.name .. " -> " .. last.action)
                               or "no prior items"
         ctxFs:SetText("Index " .. ctx.index .. " of " .. ctx.total .. "\n" .. lastTxt)
       end,

--- a/Standalone/UIShowcase.lua
+++ b/Standalone/UIShowcase.lua
@@ -172,6 +172,7 @@ local function createShowcase()
     { key = "mini",     label = "MiniView",    icon = "Interface\\Buttons\\UI-MicroButton-Inventory-Up" },
     { key = "text",     label = "Text",        icon = "Interface\\Buttons\\UI-MicroButton-Achievement-Up" },
     { key = "wizard",   label = "Wizard",      icon = "Interface\\Buttons\\UI-MicroButton-Mounts-Up" },
+    { key = "stepper",  label = "Stepper",     icon = "Interface\\Buttons\\UI-MicroButton-Quest-Up" },
     { key = "tree",     label = "Tree",        icon = "Interface\\Buttons\\UI-MicroButton-LFG-Up" },
     { key = "reorder",  label = "Reorderable", icon = "Interface\\Buttons\\UI-MicroButton-Encounter-Journal-Up" },
     { key = "tables",   label = "Tables",      icon = "Interface\\Buttons\\UI-MicroButton-Questlog-Up" },
@@ -1875,6 +1876,124 @@ pages.wizard = function(parent)
   })
   wizard:SetPoint("TOPLEFT", f, "TOPLEFT", 8, -8)
   wizard:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -8, 8)
+
+  return f
+end
+
+-- ============================================================================
+-- Page: Stepper (CreateStepper demo)
+-- ============================================================================
+
+pages.stepper = function(parent)
+  local f = CreateFrame("Frame", nil, parent)
+  f:SetAllPoints()
+
+  local intro = f:CreateFontString(nil, "OVERLAY")
+  intro:SetFontObject(cw.Fonts.normal)
+  intro:SetPoint("TOPLEFT", f, "TOPLEFT", 12, -12)
+  intro:SetPoint("RIGHT", f, "RIGHT", -12, 0)
+  intro:SetJustifyH("LEFT")
+  intro:SetWordWrap(true)
+  intro:SetTextColor(unpack(T.text))
+  intro:SetText("CreateStepper walks a queue of items one at a time with caller-defined "
+              .. "footer actions. Distinct from Wizard (fixed N-step linear flow). The "
+              .. "queue can grow mid-traversal via Push; Skip / Back / Cancel are built "
+              .. "in; cancelling returns the intact remaining queue.")
+
+  -- Demo items: pretend list of "failed posts" to repost.
+  local items = {
+    { name = "Linen Cloth",        count = 200 },
+    { name = "Heavy Junkbox",      count = 10  },
+    { name = "Mageweave Bandage",  count = 60  },
+  }
+
+  -- Demo widgets that the renderItem closure repaints each visit.
+  local itemFs, ctxFs
+
+  -- Forward-declare so closures can reach it.
+  local stepper
+
+  -- "Push more items" button below the stepper frame so we can demonstrate
+  -- mid-traversal queue growth.
+  local pushBtn, restartBtn
+
+  local stepperBox = CreateFrame("Frame", nil, f)
+  stepperBox:SetPoint("TOPLEFT",     intro, "BOTTOMLEFT",   0, -16)
+  stepperBox:SetPoint("BOTTOMRIGHT", f,     "BOTTOMRIGHT", -8, 40)
+
+  local function buildStepper()
+    stepper = cw:CreateStepper(stepperBox, {
+      title       = "Repost failed listings",
+      items       = items,
+      showProgress = true,
+      showBack    = true,
+      actions     = {
+        { key = "skip",   label = "Skip" },
+        { key = "repost", label = "Repost", style = "primary" },
+      },
+      renderItem = function(content, item, ctx)
+        if not itemFs then
+          itemFs = content:CreateFontString(nil, "OVERLAY")
+          itemFs:SetFontObject(cw.Fonts.header)
+          itemFs:SetPoint("TOPLEFT", content, "TOPLEFT", 16, -16)
+          itemFs:SetPoint("RIGHT",   content, "RIGHT",  -16, 0)
+          itemFs:SetJustifyH("LEFT")
+          itemFs:SetWordWrap(true)
+          itemFs:SetTextColor(unpack(T.gold))
+
+          ctxFs = content:CreateFontString(nil, "OVERLAY")
+          ctxFs:SetFontObject(cw.Fonts.normal)
+          ctxFs:SetPoint("TOPLEFT", itemFs, "BOTTOMLEFT", 0, -12)
+          ctxFs:SetPoint("RIGHT",   content, "RIGHT",   -16, 0)
+          ctxFs:SetJustifyH("LEFT")
+          ctxFs:SetWordWrap(true)
+          ctxFs:SetTextColor(unpack(T.text))
+        end
+
+        if item == nil then
+          itemFs:SetText("Queue empty")
+          ctxFs:SetText("Click \"Push 2 more\" below to add items mid-traversal, "
+                     .. "or Restart to begin a new run.")
+          return
+        end
+
+        itemFs:SetText(item.name .. "  ×" .. item.count)
+        local last = ctx.history[#ctx.history]
+        local lastTxt = last and ("last: " .. last.item.name .. " → " .. last.action)
+                              or "no prior items"
+        ctxFs:SetText("Index " .. ctx.index .. " of " .. ctx.total .. "\n" .. lastTxt)
+      end,
+      onAction = function(actionKey, item)
+        cw:Print("Cogworks", "stepper: " .. actionKey .. " on " .. item.name)
+      end,
+      onCancel = function(remaining)
+        cw:Print("Cogworks", "stepper cancelled; " .. #remaining .. " item(s) remained")
+      end,
+      onComplete = function()
+        cw:Print("Cogworks", "stepper complete")
+      end,
+    })
+    stepper:SetAllPoints()
+  end
+  buildStepper()
+
+  pushBtn = cw:CreateButton(f, "Push 2 more", 120, 24, function()
+    if not stepper then return end
+    stepper:Push({ name = "Runecloth",   count = 50 })
+    stepper:Push({ name = "Felcloth",    count = 20 })
+    cw:Print("Cogworks", "pushed 2 items; queue now " .. #stepper:GetRemaining())
+  end)
+  pushBtn:SetPoint("BOTTOMLEFT", f, "BOTTOMLEFT", 12, 8)
+
+  restartBtn = cw:CreateButton(f, "Restart", 100, 24, function()
+    if stepper then
+      stepper:Hide()
+      stepper:SetParent(nil)
+      itemFs, ctxFs = nil, nil
+    end
+    buildStepper()
+  end)
+  restartBtn:SetPoint("LEFT", pushBtn, "RIGHT", 8, 0)
 
   return f
 end


### PR DESCRIPTION
## Summary

Adds `cw:CreateStepper(parent, opts)` — a one-item-at-a-time walkthrough primitive. Wizard's sibling: where Wizard is a fixed N-step linear setup flow with a validation gate, Stepper walks an unknown-length queue of items with caller-defined per-item actions, Skip / Back / Cancel, and `Push` during traversal so the queue can grow.

Resolves #36. Unblocks FlipQueue's Deal Finder migration (FQ #143 phase B) and FQ #160 (failed-post recovery).

### API

```lua
local stepper = cw:CreateStepper(parent, {
  items       = { ... },                       -- initial queue (may be empty)
  title       = "Repost failed listings",      -- static header title
  -- titleFor = function(item, ctx) ... end,   -- or dynamic per-item title
  renderItem  = function(content, item, ctx) ... end,
  actions     = {
    { key = "skip",   label = "Skip" },
    { key = "repost", label = "Repost", style = "primary" },
  },
  onAction    = function(actionKey, item, ctx) ... end,  -- return false to suppress auto-advance
  onCancel    = function(remainingItems) ... end,
  onComplete  = function() ... end,
  showProgress = true,   -- "3 / 12" in header
  showBack    = true,    -- Back button in footer
})

stepper:Push(item)
stepper:Skip()
stepper:Back()
stepper:Advance(actionKey)   -- complete the current item without firing onAction (used after deferred async)
stepper:Refresh()             -- re-render current item
stepper:GetRemaining()
stepper:GetCurrent()
stepper:GetHistory()
```

`ctx` passed to `renderItem` / `onAction` is `{ index, total, history, queue }`. `index` and `total` update live as the queue grows via `Push`. `history` is a list of `{ item, action }` records — `Back` pops the most recent and re-pushes that item onto the queue front.

### MINOR

Bumps lib MINOR `20 -> 21`. New module file `Cogworks-1.0/Stepper.lua` at MODULE_MINOR 1.

### Showcase

`Standalone/UIShowcase.lua` adds a new "Stepper" sidebar page demonstrating the full surface: three demo items, primary-style Repost action, Skip, Back, "Push 2 more" button to exercise mid-traversal growth, and a Restart button.

## Test plan

- [ ] `/cogworks ui` → click **Stepper** in the sidebar.
- [ ] **Progress** display reads `1 / 3` initially; cycles `2 / 3`, `3 / 3` as you act on each item.
- [ ] **Skip** advances without firing the `repost` action (chat shows `stepper: skip on <item>`).
- [ ] **Repost** (primary, gold border) fires `stepper: repost on <item>` and advances.
- [ ] **Back** re-shows the previous item; the prior action is visible in `ctx.history` (the body's "last: …" line shows it).
- [ ] **Push 2 more** appends two items; progress total grows by 2; if queue was empty (post-complete), the new items become current.
- [ ] **Cancel** closes the page interaction with `stepper cancelled; N item(s) remained` in chat.
- [ ] **Complete** state (act on all items): footer action buttons disable; Back still works; chat fires `stepper complete`.
- [ ] **Restart** rebuilds the demo from scratch.

## Notes

- Filed as the first of the three FlipQueue v0.13 adoption-audit unblockers (#36 / #38 / #40). #38 and #40 follow as separate PRs.
- Conflicts with #54 (which also bumps MINOR `20 -> 21`); whichever lands second will rebase + bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)