### PR TITLE
fix(COG-69): CreateDebugConsole tab-overlap on switch (v0.14.1 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Cogworks-1.0 are tracked here. The library is **additive only** — old APIs never disappear, so every entry below is something gained, never lost.
 
+## [0.14.1] — 2026-05-14 — CreateDebugConsole tab-overlap hotfix (COG-69)
+
+Bumps `MINOR` from `26` to `27`. Hotfix for a developer-visible regression unmasked by v0.14.0: switching between Actions / Inspectors / Profile / Log tabs in `CreateDebugConsole` no longer hides the previous tab's chrome, so all four tabs' contents pile onto the shared content frame and overlap visibly.
+
+### Fixed
+
+- **`CreateDebugConsole` tab overlap on tab switch** (`Cogworks-1.0/Debug.lua`, MODULE_MINOR `3 → 4`, COG-69) — each of `_buildActions` / `_buildInspectors` / `_buildProfile` / `_buildLog` now wraps its chrome in a per-tab page frame and returns it, and the tab `build` thunks pass that return value through to `TabPanel`. Previously the builders added children directly to the shared content frame and returned nothing, leaving `TabPanel.tabPages[key]` nil — so `setActive` had nothing to `Hide()` on the previous tab and the chrome accumulated. Latent since v0.13.0, but masked by COG-56 (`attempt to call a nil value` on initial activation) until v0.14.0; clicking a different tab in the console now correctly swaps the visible content.
+
+### Notes
+
+- Consumer cogs should re-pin `.pkgmeta` Cogworks external to v0.14.1. Per-module guards mean a single v0.14.1 install supersedes vendored v0.14.0 `Debug.lua` copies, but every cog should still re-pin for safety.
+
 ## [0.14.0] — 2026-05-14 — Async + interaction primitives, FQ-audit feed-in
 
 Bumps `MINOR` from `19` to `26`. Eight new / extended primitives from the FlipQueue v0.13 adoption audit (FQ #143) plus two fixes — one player-visible (standalone minimap inner-glyph artwork) and one developer-visible (debug console crash on open).

--- a/Cogworks-1.0/Cogworks-1.0.lua
+++ b/Cogworks-1.0/Cogworks-1.0.lua
@@ -25,7 +25,7 @@ assert(LibStub:GetLibrary("CallbackHandler-1.0", true), "Cogworks-1.0 requires C
 -- because every consumer ships the same external, the path resolves either way.
 local LIB_LOADER_ADDON = ...
 
-local MAJOR, MINOR = "Cogworks-1.0", 26
+local MAJOR, MINOR = "Cogworks-1.0", 27
 local lib, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end  -- already loaded at this version or newer
 oldminor = oldminor or 0
@@ -35,7 +35,7 @@ lib.loaderAddon = lib.loaderAddon or LIB_LOADER_ADDON
 -- Version
 -- ============================================================================
 
-lib.version      = "0.14.0"  -- human-facing semver of the Cogworks suite
+lib.version      = "0.14.1"  -- human-facing semver of the Cogworks suite
 lib.minorVersion = MINOR     -- LibStub minor; bumps on any API addition
 
 -- ============================================================================

--- a/Cogworks-1.0/Debug.lua
+++ b/Cogworks-1.0/Debug.lua
@@ -42,7 +42,7 @@
 local lib = LibStub("Cogworks-1.0")
 if not lib then return end
 
-local MODULE_MINOR = 3
+local MODULE_MINOR = 4
 lib._modules = lib._modules or {}
 if (lib._modules.Debug or 0) >= MODULE_MINOR then return end
 lib._modules.Debug = MODULE_MINOR
@@ -575,10 +575,15 @@ function lib:CreateDebugConsole(opts)
   local panel = self:CreateTabPanel(tabHost, {
     lazy = true,
     tabs = {
-      { key = "actions",    label = "Actions",    build = function(p) f._buildActions(p)    end },
-      { key = "inspectors", label = "Inspectors", build = function(p) f._buildInspectors(p) end },
-      { key = "profile",    label = "Profile",    build = function(p) f._buildProfile(p)    end },
-      { key = "log",        label = "Log",        build = function(p) f._buildLog(p)        end },
+      -- Each builder returns a per-tab wrapper frame so TabPanel can
+      -- Show/Hide it as a unit on tab switch. Returning nothing leaves
+      -- `tabPages[key]` nil in TabPanel, which means setActive can't
+      -- hide the previous tab and all tabs' chrome accumulates on the
+      -- shared content frame (COG-69).
+      { key = "actions",    label = "Actions",    build = function(p) return f._buildActions(p)    end },
+      { key = "inspectors", label = "Inspectors", build = function(p) return f._buildInspectors(p) end },
+      { key = "profile",    label = "Profile",    build = function(p) return f._buildProfile(p)    end },
+      { key = "log",        label = "Log",        build = function(p) return f._buildLog(p)        end },
     },
     onActivate = function(key)
       if key == "log"     and f._refreshLog     then f._refreshLog()     end
@@ -622,6 +627,13 @@ function lib:CreateDebugConsole(opts)
   -- ============================================================================
 
   function f._buildActions(parent)
+    -- Per-tab wrapper so TabPanel can Show/Hide this tab's chrome as a unit
+    -- on tab switch. Without this, every tab's children would pile onto the
+    -- shared content frame and visibly overlap (COG-69).
+    local page = CreateFrame("Frame", nil, parent)
+    page:SetAllPoints()
+    parent = page
+
     local pad = 8
     local btnW, btnH, gap = 240, 24, 6
     local HEADER_H = 18
@@ -737,9 +749,16 @@ function lib:CreateDebugConsole(opts)
     -- the console being hidden / re-shown. (COG-43)
     d._actionRebuilders = d._actionRebuilders or {}
     d._actionRebuilders[#d._actionRebuilders + 1] = rebuild
+
+    return page
   end
 
   function f._buildInspectors(parent)
+    -- Per-tab wrapper for tab switching (COG-69).
+    local page = CreateFrame("Frame", nil, parent)
+    page:SetAllPoints()
+    parent = page
+
     local pad = 8
 
     local row = CreateFrame("Frame", nil, parent)
@@ -827,9 +846,16 @@ function lib:CreateDebugConsole(opts)
       listContent:SetWidth(listScroll:GetWidth())
     end
     rebuildList()
+
+    return page
   end
 
   function f._buildProfile(parent)
+    -- Per-tab wrapper for tab switching (COG-69).
+    local page = CreateFrame("Frame", nil, parent)
+    page:SetAllPoints()
+    parent = page
+
     local pad = 8
 
     local row = CreateFrame("Frame", nil, parent)
@@ -891,9 +917,16 @@ function lib:CreateDebugConsole(opts)
       content:SetWidth(scroll:GetWidth())
     end
     f._refreshProfile()
+
+    return page
   end
 
   function f._buildLog(parent)
+    -- Per-tab wrapper for tab switching (COG-69).
+    local page = CreateFrame("Frame", nil, parent)
+    page:SetAllPoints()
+    parent = page
+
     local pad = 8
 
     local row = CreateFrame("Frame", nil, parent)
@@ -953,6 +986,8 @@ function lib:CreateDebugConsole(opts)
       end
     end
     f._refreshLog()
+
+    return page
   end
 
   function f:RebuildActions()


### PR DESCRIPTION
## Summary

Hotfix for the developer-visible regression unmasked by v0.14.0: switching tabs in `CreateDebugConsole` left every tab's chrome visible on the shared content frame, producing visible overlap.

Each tab builder now wraps its chrome in a per-tab page frame and returns it; the tab `build` thunks pass that return value through so `TabPanel.tabPages[key]` is populated and `setActive` can `Hide()` the previous tab on switch.

## Effects

- `Cogworks-1.0/Debug.lua` MODULE_MINOR `3 -> 4`
- Lib MINOR `26 -> 27`
- `lib.version` `0.14.0 -> 0.14.1`
- CHANGELOG: new `[0.14.1]` section
- Closes #69

## Test plan

- [x] CI `verify-package` passes
- [ ] In-game: `/cogworks ui` -> Debug -> Open debug console, click between Actions / Inspectors / Profile / Log tabs; only the active tab's content is visible at any time, no chrome carryover

## Hotfix prep

Branch + PR ready for v0.14.1 tag once you give the go-ahead. Per CLAUDE.md release flow: tag with `v0.14.1`, push, BigWigsMods packager fires, CF + Wago upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)