### PR TITLE
feat(COG-71): CreateAppearanceTab alias + Appearance-tab convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Cogworks-1.0 are tracked here. The library is **additive only** — old APIs never disappear, so every entry below is something gained, never lost.
 
+## Unreleased
+
+- **`cw:CreateAppearanceTab(parent, opts)` + adoption convention** (`Cogworks-1.0/Scaling.lua`, MODULE_MINOR `2 → 3`, COG-71) — additive clear-intent alias for `CreateUIScalingSettingsBlock`. Both functions are identical; the new name names the convention: every cog's settings UI ends with an **"Appearance"** tab whose body is a single `cw:CreateAppearanceTab(parent, { cog = "MyCog" })` call. Cog-specific toggles / pickers go in **other** tabs; Appearance is reserved for the standard suite-wide primitive so future UX improvements (theme color editor, new overrides, etc.) reach every cog the day they ship. All writes flow through cogworks into `CogworksSharedDB`. Per-cog overrides for `fontScale` + `fontFamily` are scoped to `cog`; `uiScale` + theme stay suite-wide for the v0.14.x line (per-cog theme is a planned multi-release stretch — filed as a follow-up cogworks issue). Adoption tickets for Tally + FlipQueue are filed on their respective trackers. Showcase page at `/cogworks ui` → "Appearance tab" demos the canonical pattern. Bumps lib MINOR `27 → 28`.
+
 ## [0.14.1] — 2026-05-14 — CreateDebugConsole tab-overlap hotfix (COG-69)
 
 Bumps `MINOR` from `26` to `27`. Hotfix for a developer-visible regression unmasked by v0.14.0: switching between Actions / Inspectors / Profile / Log tabs in `CreateDebugConsole` no longer hides the previous tab's chrome, so all four tabs' contents pile onto the shared content frame and overlap visibly.

--- a/Cogworks-1.0/Cogworks-1.0.lua
+++ b/Cogworks-1.0/Cogworks-1.0.lua
@@ -25,7 +25,7 @@ assert(LibStub:GetLibrary("CallbackHandler-1.0", true), "Cogworks-1.0 requires C
 -- because every consumer ships the same external, the path resolves either way.
 local LIB_LOADER_ADDON = ...
 
-local MAJOR, MINOR = "Cogworks-1.0", 27
+local MAJOR, MINOR = "Cogworks-1.0", 28
 local lib, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end  -- already loaded at this version or newer
 oldminor = oldminor or 0

--- a/Cogworks-1.0/Scaling.lua
+++ b/Cogworks-1.0/Scaling.lua
@@ -1,25 +1,62 @@
 -- Cogworks-1.0/Scaling.lua | UI scaling settings block + per-frame scale registration.
 --
--- Two consumer-facing primitives:
+-- Consumer-facing primitives:
+--
+--   cw:CreateAppearanceTab(parent, opts)
+--     **Preferred entry point.** Builds the standard cogworks-managed
+--     appearance controls (profile picker + per-cog override + font/UI scale
+--     sliders + font family + theme dropdown + reset). Drop into a dedicated
+--     tab in every cog's settings UI for suite-wide consistency. (COG-71)
 --
 --   cw:CreateUIScalingSettingsBlock(parent, opts)
---     Drop-in section for any cog's settings page. Exposes profile dropdown,
---     font/UI scale sliders, font family + theme dropdowns, reset button, and
---     (when opts.cog is set) the per-cog override controls.
+--     Legacy name for the same primitive. Kept for back-compat; prefer
+--     CreateAppearanceTab in new code.
 --
 --   cw:RegisterScalingFrame(frame, opts)
 --     Subscribes a frame to SettingsChanged for uiScale so SetScale fires
 --     automatically. Optionally persists frame geometry into a caller-owned SV
 --     table.
 --
--- Both build on the lib's existing settings/profile API (Cogworks-1.0.lua) and
--- the SettingsChanged event bus.
+-- ============================================================================
+-- Appearance-tab convention (COG-71)
+-- ============================================================================
+-- Every cog should expose cogworks-managed appearance settings in a dedicated
+-- tab inside its own settings UI. The convention:
+--
+--   * Tab label:     "Appearance"
+--   * Tab position:  last tab in the cog's settings TabPanel
+--   * Tab body:      a single call to cw:CreateAppearanceTab(parent, { cog = "MyCog" })
+--   * Cog-specific:  toggles / picker rows / debug knobs go in OTHER tabs.
+--                    The Appearance tab is reserved for the standard primitive
+--                    so suite-wide UX improvements (color editors, new
+--                    overrides, etc.) reach every cog the day they ship.
+--
+-- Persistence: all writes flow through cogworks into CogworksSharedDB
+-- (account-wide, shared by every cog). Per-cog overrides for fontScale +
+-- fontFamily are scoped to `cog`; uiScale + theme stay suite-wide for the
+-- v0.14.x line (per-cog theme is a planned multi-release stretch).
+--
+-- Adoption example (in a cog's main settings TabPanel):
+--
+--   local panel = cw:CreateTabPanel(parent, {
+--     tabs = {
+--       { key = "general",    label = "General",    build = function(c) ... end },
+--       { key = "scanner",    label = "Scanner",    build = function(c) ... end },
+--       -- ... cog-specific tabs ...
+--       { key = "appearance", label = "Appearance",
+--         build = function(c)
+--           return cw:CreateAppearanceTab(c, { cog = "MyCog" })
+--         end },
+--     },
+--   })
+--
+-- See Standalone/UIShowcase.lua -> "Appearance" page for a runnable demo.
 
 local lib = LibStub("Cogworks-1.0")
 if not lib then return end
 
 -- Module load guard. See Sections.lua for rationale.
-local MODULE_MINOR = 2
+local MODULE_MINOR = 3
 lib._modules = lib._modules or {}
 if (lib._modules.Scaling or 0) >= MODULE_MINOR then return end
 lib._modules.Scaling = MODULE_MINOR
@@ -490,6 +527,15 @@ function lib:CreateUIScalingSettingsBlock(parent, opts)
   block.themeDropdown   = themeDD
   block.resetButton     = resetBtn
   return block
+end
+
+-- Preferred entry point. Identical to CreateUIScalingSettingsBlock; the name
+-- makes the convention from the top-of-file comment unambiguous at call sites
+-- (`local appearance = cw:CreateAppearanceTab(content, { cog = "MyCog" })`).
+-- See the Appearance-tab convention block above for the standard adoption
+-- shape (dedicated last tab in the cog's settings TabPanel). (COG-71)
+function lib:CreateAppearanceTab(parent, opts)
+  return self:CreateUIScalingSettingsBlock(parent, opts)
 end
 
 -- ============================================================================

--- a/Standalone/UIShowcase.lua
+++ b/Standalone/UIShowcase.lua
@@ -188,6 +188,7 @@ local function createShowcase()
     { key = "toast",    label = "Toast",       icon = "Interface\\COMMON\\Indicator-Yellow" },
     { key = "loading",  label = "Loading",     icon = "Interface\\COMMON\\StreamCircle" },
     { key = "tasks",    label = "Task progress", icon = "Interface\\COMMON\\Indicator-Green" },
+    { key = "appearance", label = "Appearance tab", icon = "Interface\\Buttons\\UI-MicroButton-Collections-Up" },
     { key = "slash",    label = "Slash",       icon = "Interface\\Buttons\\UI-MicroButton-Help-Up" },
   }
 
@@ -2987,6 +2988,87 @@ pages.tasks = function(parent)
     _multiTicker:SetScript("OnUpdate", nil)
   end)
   hideMultiBtn:SetPoint("TOPLEFT", startMultiBtn, "BOTTOMLEFT", 0, -8)
+
+  return f
+end
+
+-- ============================================================================
+-- Page: Appearance tab convention (COG-71)
+-- ============================================================================
+-- Demonstrates the standard adoption pattern: a cog's settings UI uses a
+-- TabPanel where the LAST tab is "Appearance" and its body is a single
+-- cw:CreateAppearanceTab(parent, { cog = "<cog>" }) call. Cog-specific
+-- toggles / pickers go in OTHER tabs; the Appearance tab is reserved for
+-- the standard suite-wide primitive so future UX improvements (theme color
+-- editor, new overrides, etc.) reach every cog the day they ship.
+
+pages.appearance = function(parent)
+  local f = CreateFrame("Frame", nil, parent)
+  f:SetAllPoints()
+
+  local intro = f:CreateFontString(nil, "OVERLAY")
+  intro:SetFontObject(cw.Fonts.small)
+  intro:SetPoint("TOPLEFT", f, "TOPLEFT", 12, -12)
+  intro:SetPoint("RIGHT",   f, "RIGHT",   -12, 0)
+  intro:SetJustifyH("LEFT")
+  intro:SetWordWrap(true)
+  intro:SetTextColor(unpack(T.textDim))
+  intro:SetText("Convention (COG-71): every cog's settings UI ends with an 'Appearance' tab whose body is a single "
+              .. "cw:CreateAppearanceTab(parent, { cog = '<cog>' }) call. Suite-wide UX improvements (theme color "
+              .. "editor, new overrides) reach every cog the day they ship. Below is a fake cog settings page with "
+              .. "two cog-specific tabs followed by the standard Appearance tab. The per-cog override checkbox at "
+              .. "the top of the Appearance tab toggles whether this 'cog' uses its own profile or follows suite-active.")
+
+  local mockSettings = CreateFrame("Frame", nil, f)
+  mockSettings:SetPoint("TOPLEFT",     intro,           "BOTTOMLEFT",  0, -16)
+  mockSettings:SetPoint("BOTTOMRIGHT", f,               "BOTTOMRIGHT", -12, 12)
+
+  cw:CreateTabPanel(mockSettings, {
+    tabs = {
+      { key = "general", label = "General",
+        build = function(c)
+          local p = CreateFrame("Frame", nil, c); p:SetAllPoints()
+          local fs = p:CreateFontString(nil, "OVERLAY")
+          fs:SetFontObject(cw.Fonts.normal)
+          fs:SetPoint("TOPLEFT", p, "TOPLEFT", 16, -16)
+          fs:SetPoint("RIGHT", p, "RIGHT", -16, 0)
+          fs:SetJustifyH("LEFT")
+          fs:SetWordWrap(true)
+          fs:SetTextColor(unpack(T.text))
+          fs:SetText("This is where a cog's general toggles live: enable scanner, show minimap button, etc. "
+                  .. "Anything cog-specific stays out of the Appearance tab so the standard primitive's UX "
+                  .. "matches across the suite.")
+          return p
+        end },
+      { key = "data", label = "Data",
+        build = function(c)
+          local p = CreateFrame("Frame", nil, c); p:SetAllPoints()
+          local fs = p:CreateFontString(nil, "OVERLAY")
+          fs:SetFontObject(cw.Fonts.normal)
+          fs:SetPoint("TOPLEFT", p, "TOPLEFT", 16, -16)
+          fs:SetPoint("RIGHT", p, "RIGHT", -16, 0)
+          fs:SetJustifyH("LEFT")
+          fs:SetWordWrap(true)
+          fs:SetTextColor(unpack(T.text))
+          fs:SetText("Another cog-specific tab. Filters / data retention / import settings. "
+                  .. "The cog owns the layout and content of every tab except 'Appearance'.")
+          return p
+        end },
+      { key = "appearance", label = "Appearance",
+        build = function(c)
+          -- The canonical one-call body of every cog's Appearance tab.
+          -- `cog = "ShowcaseDemo"` opts the demo into the per-cog override
+          -- controls (checkbox + profile dropdown at the top of the block);
+          -- swap "ShowcaseDemo" for the actual cog name in real adoption.
+          return cw:CreateAppearanceTab(c, {
+            cog         = "ShowcaseDemo",
+            description = "Suite-wide appearance: profile, fonts, theme. Toggle the per-cog override "
+                       .. "at the top to give this cog its own font scale + family while leaving the "
+                       .. "rest of the suite at the active profile.",
+          })
+        end },
+    },
+  }):SetAllPoints(mockSettings)
 
   return f
 end


### PR DESCRIPTION
## Summary

Lands the convention work from the v0.14 settings-UX discussion. Same primitive, new name + canonical adoption shape.

- `cw:CreateAppearanceTab(parent, opts)` — additive alias for `CreateUIScalingSettingsBlock`
- Convention block at top of `Scaling.lua` documents: tab labelled **"Appearance"**, last position in each cog's TabPanel, body is the one-call primitive
- Showcase page at `/cogworks ui` → "Appearance tab" demos a fake cog-settings TabPanel with two cog-specific tabs followed by the standard Appearance tab

## Effects

- `Cogworks-1.0/Scaling.lua` MODULE_MINOR `2 → 3`
- Lib MINOR `27 → 28`
- No release tagged — banking against future v0.14.2 with whatever Tally adoption surfaces

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)