### PR TITLE
fix(COG-75): CreateAppearanceTab anchors its block (was empty tab)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Cogworks-1.0 are tracked here. The library is **additive only** — old APIs never disappear, so every entry below is something gained, never lost.
 
+## [0.14.3] — 2026-05-15 — CreateAppearanceTab empty-tab hotfix (COG-75)
+
+Bumps `MINOR` from `28` to `29`. Hotfix for the COG-71 primitive shipped in v0.14.2: `cw:CreateAppearanceTab` rendered a visible tab with no controls inside it.
+
+### Fixed
+
+- **`CreateAppearanceTab` renders an empty tab** (`Cogworks-1.0/Scaling.lua`, MODULE_MINOR `3 → 4`, COG-75) — `CreateUIScalingSettingsBlock` creates its `block` frame with `SetSize` but no `SetPoint` (its contract is "caller positions it"). `CreateAppearanceTab` returned that unanchored block straight to `TabPanel`, which only `Show`/`Hide`s the page frame a `build` returns — it never anchors it. With no anchor the block had no valid rect, so it and all its controls (profile dropdown, sliders, theme picker, reset) rendered nowhere visible. `CreateAppearanceTab` now anchors the block `TOPLEFT` + `TOPRIGHT` to its parent before returning, so the convention's one-call tab body works. `CreateUIScalingSettingsBlock` keeps its existing "caller positions it" contract (zero direct adopters — no behaviour change).
+
+### Notes
+
+- Consumer cogs should re-pin `.pkgmeta` Cogworks external to v0.14.3. No cog had adopted `CreateAppearanceTab` yet, so no player saw a broken settings tab — this lands the fix ahead of the first consumer migration (Tally, `gezmodean-wow/tally#72`).
+
 ## [0.14.2] — 2026-05-14 — Appearance-tab convention (COG-71)
 
 Bumps `MINOR` from `27` to `28`. Names the standard cogworks-managed appearance controls and the canonical adoption shape for sibling cogs. No player-visible behaviour change — additive library work for cog authors.

--- a/Cogworks-1.0/Cogworks-1.0.lua
+++ b/Cogworks-1.0/Cogworks-1.0.lua
@@ -25,7 +25,7 @@ assert(LibStub:GetLibrary("CallbackHandler-1.0", true), "Cogworks-1.0 requires C
 -- because every consumer ships the same external, the path resolves either way.
 local LIB_LOADER_ADDON = ...
 
-local MAJOR, MINOR = "Cogworks-1.0", 28
+local MAJOR, MINOR = "Cogworks-1.0", 29
 local lib, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end  -- already loaded at this version or newer
 oldminor = oldminor or 0
@@ -35,7 +35,7 @@ lib.loaderAddon = lib.loaderAddon or LIB_LOADER_ADDON
 -- Version
 -- ============================================================================
 
-lib.version      = "0.14.2"  -- human-facing semver of the Cogworks suite
+lib.version      = "0.14.3"  -- human-facing semver of the Cogworks suite
 lib.minorVersion = MINOR     -- LibStub minor; bumps on any API addition
 
 -- ============================================================================

--- a/Cogworks-1.0/Scaling.lua
+++ b/Cogworks-1.0/Scaling.lua
@@ -56,7 +56,7 @@ local lib = LibStub("Cogworks-1.0")
 if not lib then return end
 
 -- Module load guard. See Sections.lua for rationale.
-local MODULE_MINOR = 3
+local MODULE_MINOR = 4
 lib._modules = lib._modules or {}
 if (lib._modules.Scaling or 0) >= MODULE_MINOR then return end
 lib._modules.Scaling = MODULE_MINOR
@@ -529,13 +529,24 @@ function lib:CreateUIScalingSettingsBlock(parent, opts)
   return block
 end
 
--- Preferred entry point. Identical to CreateUIScalingSettingsBlock; the name
--- makes the convention from the top-of-file comment unambiguous at call sites
--- (`local appearance = cw:CreateAppearanceTab(content, { cog = "MyCog" })`).
+-- Preferred entry point for the Appearance-tab convention. Builds the same
+-- controls as CreateUIScalingSettingsBlock, but returns a block already
+-- anchored to fill `parent` — so it works as a one-call TabPanel `build`
+-- body without the caller needing a follow-up SetPoint.
+--
+-- CreateUIScalingSettingsBlock itself returns an *unanchored* block (its
+-- contract is "caller positions it"). TabPanel only Show/Hides the frame a
+-- `build` returns — it never anchors it — so handing the raw unanchored
+-- block to a tab renders an empty tab (COG-75). This wrapper closes that gap.
+--
 -- See the Appearance-tab convention block above for the standard adoption
 -- shape (dedicated last tab in the cog's settings TabPanel). (COG-71)
 function lib:CreateAppearanceTab(parent, opts)
-  return self:CreateUIScalingSettingsBlock(parent, opts)
+  local block = self:CreateUIScalingSettingsBlock(parent, opts)
+  block:ClearAllPoints()
+  block:SetPoint("TOPLEFT",  parent, "TOPLEFT",  0, 0)
+  block:SetPoint("TOPRIGHT", parent, "TOPRIGHT", 0, 0)
+  return block
 end
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

Hotfix for the COG-71 primitive shipped in v0.14.2 — `cw:CreateAppearanceTab` rendered a visible tab with no controls inside.

`CreateUIScalingSettingsBlock` creates its `block` with `SetSize` but no `SetPoint` ("caller positions it" contract). `CreateAppearanceTab` returned that unanchored block to `TabPanel`, which only `Show`/`Hide`s the page a `build` returns and never anchors it — so the block had no valid rect and rendered nothing visible.

Fix: `CreateAppearanceTab` anchors the block `TOPLEFT` + `TOPRIGHT` to its parent before returning. `CreateUIScalingSettingsBlock` keeps its contract unchanged (zero direct adopters).

## Effects

- `Cogworks-1.0/Scaling.lua` MODULE_MINOR `3 → 4`
- Lib MINOR `28 → 29`, `lib.version` `0.14.2 → 0.14.3`
- Closes #75

## Test plan

- [x] CI `verify-package`
- [ ] In-game: `/cogworks ui` → "Appearance tab" — the Appearance tab now shows the full control set (profile picker, per-cog override, font/UI sliders, font family + theme dropdowns, reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)